### PR TITLE
[Fixes #99381676] A \r from Windows was causing the parser to generat…

### DIFF
--- a/core/htmlparser.js
+++ b/core/htmlparser.js
@@ -295,6 +295,8 @@ define(function(require, exports, module){
 		 *
 		 */
 		this.parse = function(source){
+                        // Windows \r messes up parsing
+                        source = source.replace(/\r/g,'')
 			// lets create some state
 			var root = this.node = this.createNode('$root',0)
 


### PR DESCRIPTION
…e errors on Windows. Removing them seems to solve the problem.