### PR TITLE
Dynamic editing using a stream of serialized edits over a socket

### DIFF
--- a/classes/behavior/overborder.dre
+++ b/classes/behavior/overborder.dre
@@ -26,8 +26,35 @@ SOFTWARE. -->
   <attribute name="overspeed" type="number" value="400"/>
   <attribute name="outspeed" type="number" value="400"/>
 
-  <handler event="onmouseover" reference="this.parent" method="show"></handler>
-  <handler event="onmouseout" reference="this.parent" method="hide"></handler>
+  <handler name="show" event="onmouseover" reference="this.parent">
+    // Check for parent since over/out events will still occur when this
+    // behavior has been temporarily orphaned via a create/delete undoable.
+    if (this.parent) {
+      var speed = this.overspeed,
+        hlt = this.__hlt;
+      if (!hlt) {
+        hlt = this.__hlt = this.parent.createChild({
+          class:'view', ignoreplacement:true, ignorelayout:true, opacity:0,
+          width:'100%', height:'100%', bordercolor:this.color
+        });
+      }
+      
+      hlt.moveToFront();
+      hlt.stopActiveAnimators('border');
+      hlt.stopActiveAnimators('opacity');
+      hlt.animate({attribute:'border', to:this.thickness, duration:speed/2});
+      hlt.animate({attribute:'opacity', to:this.opacity, duration:speed});
+    }
+  </handler>
+
+  <handler name="hide" event="onmouseout" reference="this.parent">
+    var speed = this.outspeed,
+      hlt = this.__hlt;
+    hlt.stopActiveAnimators('border');
+    hlt.stopActiveAnimators('opacity');
+    hlt.animate({attribute:'border', to:0, duration:speed});
+    hlt.animate({attribute:'opacity', to:0, duration:speed});
+  </handler>
 
   <handler event="onselected" reference="this.parent" args="sel">
     if (sel) {
@@ -37,38 +64,11 @@ SOFTWARE. -->
     }
   </handler>
 
-
-  <method name="show">
-    var speed = this.overspeed,
-      hlt = this.__hlt;
-    if (!hlt) {
-      hlt = this.__hlt = this.parent.createChild({
-        class:'view', ignoreplacement:true, ignorelayout:true, opacity:0,
-        width:'100%', height:'100%', bordercolor:this.color
-      });
-    }
-    
-    hlt.moveToFront();
-    hlt.stopActiveAnimators('border');
-    hlt.stopActiveAnimators('opacity');
-    hlt.animate({attribute:'border', to:this.thickness, duration:speed/2});
-    hlt.animate({attribute:'opacity', to:this.opacity, duration:speed});
-  </method>
-
-  <method name="hide">
-    var speed = this.outspeed,
-      hlt = this.__hlt;
-    hlt.stopActiveAnimators('border');
-    hlt.stopActiveAnimators('opacity');
-    hlt.animate({attribute:'border', to:0, duration:speed});
-    hlt.animate({attribute:'opacity', to:0, duration:speed});
-  </method>
-  
   <!--// Editor Support //-->
   <method name="__getBehaviorDomains">
     return {behavior_overborder:true}; // Don't allow two of this behavior
   </method>
-  
+
   <method name="__behaviorMakesViews">
     return true;
   </method>

--- a/classes/behavior/scale.dre
+++ b/classes/behavior/scale.dre
@@ -25,8 +25,32 @@ SOFTWARE. -->
   <attribute name="scaleoutduration" type="number" value="400"/>
   <attribute name="bringtofront" type="boolean" value="true"/>
 
-  <handler event="onmouseover" reference="this.parent" method="show"></handler>
-  <handler event="onmouseout" reference="this.parent" method="hide"></handler>
+  <handler name="show" event="onmouseover" reference="this.parent">
+    var parent = this.parent,
+      magnitude = this.magnitude;
+    // Check for parent since over/out events will still occur when this
+    // behavior has been temporarily orphaned via a create/delete undoable.
+    if (parent) {
+      parent.stopActiveAnimators('xscale');
+      parent.stopActiveAnimators('yscale');
+      parent.animate({attribute:'xscale', to:magnitude, duration:this.scaleinduration});
+      parent.animate({attribute:'yscale', to:magnitude, duration:this.scaleinduration});
+      
+      if (this.bringtofront) parent.moveToFront();
+    }
+  </handler>
+
+  <handler name="hide" event="onmouseout" reference="this.parent">
+    var parent = this.parent;
+    // Check for parent since over/out events will still occur when this
+    // behavior has been temporarily orphaned via a create/delete undoable.
+    if (parent) {
+      parent.stopActiveAnimators('xscale');
+      parent.stopActiveAnimators('yscale');
+      parent.animate({attribute:'xscale', to:1, duration:this.scaleoutduration});
+      parent.animate({attribute:'yscale', to:1, duration:this.scaleoutduration});
+    }
+  </handler>
 
   <handler event="onselected" reference="this.parent" args="sel">
     if (sel) {
@@ -35,25 +59,6 @@ SOFTWARE. -->
       this.hide();
     }
   </handler>
-
-  <method name="show">
-    var parent = this.parent,
-      magnitude = this.magnitude;
-    parent.stopActiveAnimators('xscale');
-    parent.stopActiveAnimators('yscale');
-    parent.animate({attribute:'xscale', to:magnitude, duration:this.scaleinduration});
-    parent.animate({attribute:'yscale', to:magnitude, duration:this.scaleinduration});
-    
-    if (this.bringtofront) parent.moveToFront();
-  </method>
-
-  <method name="hide">
-    var parent = this.parent;
-    parent.stopActiveAnimators('xscale');
-    parent.stopActiveAnimators('yscale');
-    parent.animate({attribute:'xscale', to:1, duration:this.scaleoutduration});
-    parent.animate({attribute:'yscale', to:1, duration:this.scaleoutduration});
-  </method>
 
   <!--// Editor Support //-->
   <method name="__getBehaviorDomains">

--- a/classes/behavior/shift.dre
+++ b/classes/behavior/shift.dre
@@ -22,40 +22,44 @@ SOFTWARE. -->
 <class name="behavior-shift" extends="node" with="behavior-behavior">
   <attribute name="xshift" type="number" value="0"/>
   <attribute name="yshift" type="number" value="20"/>
-  
+
   <method name="initNode" args="parent, attrs">
     this.__shifted = false;
     
     this.super();
   </method>
-  
+
   <handler event="onclick" reference="this.parent">
     var parent = this.parent;
-    if (this.__shifted = !this.__shifted) {
-      var xshift = this.xshift;
-      if (xshift !== 0) {
-        var origX = this.__origX = parent.x;
-        parent.stopActiveAnimators('x');
-        parent.animate({attribute:'x', to:origX + xshift, duration:800});
-      }
-      
-      var yshift = this.yshift;
-      if (yshift !== 0) {
-        var origY = this.__origY = parent.y;
-        parent.stopActiveAnimators('y');
-        parent.animate({attribute:'y', to:origY + yshift, duration:800});
-      }
-    } else {
-      var origX = this.__origX;
-      if (parent.x !== origX) {
-        parent.stopActiveAnimators('x');
-        parent.animate({attribute:'x', to:origX, duration:400});
-      }
-      
-      var origY = this.__origY;
-      if (parent.y !== origY) {
-        parent.stopActiveAnimators('y');
-        parent.animate({attribute:'y', to:origY, duration:400});
+    // Check for parent since click events will still occur when this
+    // behavior has been temporarily orphaned via a create/delete undoable.
+    if (parent) {
+      if (this.__shifted = !this.__shifted) {
+        var xshift = this.xshift;
+        if (xshift !== 0) {
+          var origX = this.__origX = parent.x;
+          parent.stopActiveAnimators('x');
+          parent.animate({attribute:'x', to:origX + xshift, duration:800});
+        }
+        
+        var yshift = this.yshift;
+        if (yshift !== 0) {
+          var origY = this.__origY = parent.y;
+          parent.stopActiveAnimators('y');
+          parent.animate({attribute:'y', to:origY + yshift, duration:800});
+        }
+      } else {
+        var origX = this.__origX;
+        if (parent.x !== origX) {
+          parent.stopActiveAnimators('x');
+          parent.animate({attribute:'x', to:origX, duration:400});
+        }
+        
+        var origY = this.__origY;
+        if (parent.y !== origY) {
+          parent.stopActiveAnimators('y');
+          parent.animate({attribute:'y', to:origY, duration:400});
+        }
       }
     }
   </handler>

--- a/classes/editor/attrundoable.dre
+++ b/classes/editor/attrundoable.dre
@@ -128,4 +128,49 @@
     }
     return this.super();
   </method>
+
+  <!--/**
+    * @method serialize
+    * @overrides
+    */-->
+  <method name="serialize" args="obj">
+    if (!obj) obj = {};
+    
+    // Store attrs of this undoable on the obj to be serialized. Use IDs for
+    // any node/view references since we just want to retrieve the objects
+    // from the composition during deserialization not serialize/deserialize 
+    // entire view/node objects.
+    obj.target = this.target.id || null;
+    obj.attribute = this.attribute;
+    
+    // The parent attr is a special case where the old and new values are
+    // node/view references.
+    if (this.attribute === 'parent') {
+      obj.oldvalue = this.oldvalue.id;
+      obj.newvalue = this.newvalue.id;
+    } else {
+      obj.oldvalue = this.oldvalue;
+      obj.newvalue = this.newvalue;
+    }
+    
+    return this.super(obj);
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * @overrides
+    */-->
+  <method name="deserialize" args="data">
+    // Retrieve objects via the serialized IDs.
+    if (data.target) data.target = dr.sprite.retrieveGlobal(data.target);
+    
+    // The parent attr is a special case where the old and new values are
+    // node/view references.
+    if (data.attribute === 'parent') {
+      data.oldvalue = dr.sprite.retrieveGlobal(data.oldvalue);
+      data.newvalue = dr.sprite.retrieveGlobal(data.newvalue);
+    }
+    
+    return this.super(data);
+  </method>
 </class>

--- a/classes/editor/compoundundoable.dre
+++ b/classes/editor/compoundundoable.dre
@@ -100,4 +100,34 @@
       return this;
     }
   </method>
+
+  <!--/**
+    * @method serialize
+    * Builds a serialized object from each of the child undoables.
+    * @overrides
+    */-->
+  <method name="serialize" args="obj">
+    if (!obj) obj = {};
+    var objUndoables = obj.undoables = [],
+      undoables = this.__undoables, 
+      len = undoables.length, i = 0;
+    for (; len > i;) objUndoables.push(undoables[i++].serialize());
+    return this.super(obj);
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * Deserializes each child undoable to rebuild this compound undoable.
+    * @overrides
+    */-->
+  <method name="deserialize" args="data">
+    var undoables = data.undoables;
+    if (undoables) {
+      var i = undoables.length;
+      while (i) undoables[--i] = dr.deserialize(undoables[i]);
+      data.__undoables = undoables;
+      delete data.undoables;
+    }
+    return this.super(data);
+  </method>
 </class>

--- a/classes/editor/createundoable.dre
+++ b/classes/editor/createundoable.dre
@@ -25,7 +25,15 @@
     * @attribute {dr.AccessorSupport} [target]
     * The new node/view to add.
     */-->
-  <attribute name="target" type="expression" value=""></attribute>
+  <attribute name="target" type="expression" value=""/>
+
+  <!--/** Holds attribute values needed by previewer clients to create the new 
+    * node/view. In the editor new node/views are created first and then an
+    * undoable is created for them. In a previewer we actually have to create
+    * the object so we need to know what attrs to use during instantiation.
+    * This previewinfo object is what contains that information.
+    */-->
+  <attribute name="previewinfo" type="expression" value=""/>
 
 
   <!--// METHODS ////////////////////////////////////////////////////////////-->
@@ -86,5 +94,45 @@
       }
     }
     return this;
+  </method>
+
+  <!--/**
+    * @method serialize
+    * @overrides
+    */-->
+  <method name="serialize" args="obj">
+    if (!obj) obj = {};
+    
+    // We need to know which parent to create the new object on.
+    obj.parent = this.target.parent.id || null;
+    
+    // Store the attrs used for instantiation.
+    obj.target = this.previewinfo || null;
+    
+    return this.super(obj);
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * @overrides
+    */-->
+  <method name="deserialize" args="data">
+    // Get parent to create new object on.
+    var parent;
+    if (data.parent) parent = dr.sprite.retrieveGlobal(data.parent);
+    if (!parent) {
+      dr.global.error.notifyWarn('deserialization', "Parent could not be found for createundoable: " + data.parent);
+      return null;
+    }
+    
+    // Create new instance on the parent using the previeinfo which was 
+    // stored on data.target.
+    var instance = parent.createChild(data.target);
+    if (!instance) {
+      dr.global.error.notifyWarn('deserialization', "Instance could not be found for createundoable: " + data.target);
+      return null;
+    }
+    
+    return this.super({target:instance});
   </method>
 </class>

--- a/classes/editor/deleteundoable.dre
+++ b/classes/editor/deleteundoable.dre
@@ -25,7 +25,7 @@
     * @attribute {dr.AccessorSupport} [target]
     * The node/view to remove.
     */-->
-  <attribute name="target" type="expression" value=""></attribute>
+  <attribute name="target" type="expression" value=""/>
 
 
   <!--// METHODS ////////////////////////////////////////////////////////////-->
@@ -79,9 +79,38 @@
         target.pauseConstraints();
         return this.super();
       } else {
-        dr.global.error.notifyWarn('invalidUndo', "No target provided to deleteundoable.");
+        dr.global.error.notifyWarn('invalidRedo', "No target provided to deleteundoable.");
       }
     }
     return this;
+  </method>
+
+  <!--/**
+    * @method serialize
+    * @overrides
+    */-->
+  <method name="serialize" args="obj">
+    if (!obj) obj = {};
+    
+    // Use IDs for node/view references since we just want to retrieve the 
+    // objects from the composition during deserialization not 
+    // serialize/deserialize entire view/node objects.
+    obj.target = this.target.id || null;
+    
+    return this.super(obj);
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * @overrides
+    */-->
+  <method name="deserialize" args="data">
+    // Retrieve objects via the serialized IDs. Also, note that unlike
+    // createundoable, previewinfo is not necessary since we begin by
+    // deleting an existing node/view and thus never need to create anything
+    // from scratch.
+    if (data.target) data.target = dr.sprite.retrieveGlobal(data.target);
+    
+    return this.super(data);
   </method>
 </class>

--- a/classes/editor/orderundoable.dre
+++ b/classes/editor/orderundoable.dre
@@ -55,4 +55,36 @@
     }
     return this.super();
   </method>
+
+  <!--/**
+    * @method serialize
+    * @overrides
+    */-->
+  <method name="serialize" args="obj">
+    if (!obj) obj = {};
+    
+    // Store attrs of this undoable on the obj to be serialized. Use IDs for
+    // any node/view references since we just want to retrieve the objects
+    // from the composition during deserialization not serialize/deserialize 
+    // entire view/node objects.
+    obj.target = this.target.id || null;
+    obj.oldprevsibling = this.oldprevsibling ? this.oldprevsibling.id : null;
+    obj.newprevsibling = this.newprevsibling ? this.newprevsibling.id : null;
+    
+    return this.super(obj);
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * @overrides
+    */-->
+  <method name="deserialize" args="data">
+    // Retrieve objects via the serialized IDs.
+    var retrieveFunc = dr.sprite.retrieveGlobal;
+    if (data.target) data.target = retrieveFunc(data.target);
+    if (data.oldprevsibling) data.oldprevsibling = retrieveFunc(data.oldprevsibling);
+    if (data.newprevsibling) data.newprevsibling = retrieveFunc(data.newprevsibling);
+    
+    return this.super(data);
+  </method>
 </class>

--- a/classes/editor/undoable.dre
+++ b/classes/editor/undoable.dre
@@ -95,4 +95,32 @@
     }
     return this;
   </method>
+
+  <!--/**
+    * @method serialize
+    * Serializes this undoable as a JSON string. Subclasses should implement
+    * this method and call super from that implementation. The obj passed in 
+    * is what actually gets serialized via JSON.stringify. Subclasses should 
+    * store attrs on this object as needed before calling super.
+    * @param {Object} obj An object passed up from subclasses that should
+    * contain the main payload for the undoable.
+    * @returns {String}
+    */-->
+  <method name="serialize" args="obj">
+    return JSON.stringify({classname:this.$tagname, data:obj || null});
+  </method>
+
+  <!--/**
+    * @method deserialize
+    * Restores the state of an undoable from serialized data. Subclasses should
+    * implement this method and call super from that implementation. The obj
+    * passed in is a set of attributes that will be directly assigned to this
+    * undoable instance (setAttribute is not called).
+    * @param {Object} data An object containing attribute values to be restored
+    * via direct assignment.
+    * @returns {void}
+    */-->
+  <method name="deserialize" args="obj">
+    if (obj) for (var key in obj) this[key] = obj[key];
+  </method>
 </class>

--- a/classes/editor/undostack.dre
+++ b/classes/editor/undostack.dre
@@ -8,6 +8,14 @@
   *
   * This object should be used to form the foundation of an undo/redo system
   * for an editor.
+  *
+  * @event onstackchange
+  * Fired when the location of the stack changes
+  * @param {Object} An object with a "type" property that indicates what
+  * caused the stack change. Supported types are "undostack_reset", 
+  * "undostack_do", "undostack_undo" and "undostack_redo". The do, undo and
+  * redo types also have an "undoable" property which is a reference to the
+  * undoable that caused the stack change.
   */-->
 <class name="editor-undostack" extends="node"
   requires="editor-compoundundoable editor-attrundoable editor-orderundoable editor-createundoable editor-deleteundoable"
@@ -41,7 +49,7 @@
     while (stack.length) stack.pop().destroy();
     this.__stackLoc = -1;
     this.__syncUndoabilityAttrs();
-    this.__fireStackChangeEvent();
+    this.__fireStackChangeEvent({type:'undostack_reset'});
     return this;
   </method>
 
@@ -50,8 +58,9 @@
     * @method __fireStackChangeEvent
     * @private
     */-->
-  <method name="__fireStackChangeEvent">
-    this.sendEvent('onstackchange', this.__stackLoc);
+  <method name="__fireStackChangeEvent" args="infoObj">
+    infoObj.stackloc = this.__stackLoc;
+    this.sendEvent('onstackchange', infoObj);
   </method>
 
   <!--/**
@@ -159,7 +168,7 @@
         while (stack.length > loc) stack.pop().destroy();
         stack.push(undoable);
         this.__syncUndoabilityAttrs();
-        this.__fireStackChangeEvent();
+        this.__fireStackChangeEvent({type:'undostack_do', undoable:undoable});
         return true;
       }
     }
@@ -189,13 +198,14 @@
     if (this.__executingUndoable) {
       if (errorHandler && typeof errorHandler === 'function') errorHandler({msg:'Prevent undostack loops in undo method.'});
     } else if (this.canUndo()) {
-      var error = this.__executeUndoable(this.__stack[this.__stackLoc--], callback, false);
+      var undoable = this.__stack[this.__stackLoc--],
+        error = this.__executeUndoable(undoable, callback, false);
       if (error) {
         ++this.__stackLoc;
         if (errorHandler && typeof errorHandler === 'function') errorHandler(error);
       } else {
         this.__syncUndoabilityAttrs();
-        this.__fireStackChangeEvent();
+        this.__fireStackChangeEvent({type:'undostack_undo', undoable:undoable});
         return true;
       }
     }
@@ -224,13 +234,14 @@
     if (this.__executingUndoable) {
       if (errorHandler && typeof errorHandler === 'function') errorHandler({msg:'Prevent undostack loops in redo method.'});
     } else if (this.canRedo()) {
-      var error = this.__executeUndoable(this.__stack[++this.__stackLoc], callback, true);
+      var undoable = this.__stack[++this.__stackLoc],
+        error = this.__executeUndoable(undoable, callback, true);
       if (error) {
         --this.__stackLoc;
         if (errorHandler && typeof errorHandler === 'function') errorHandler(error);
       } else {
         this.__syncUndoabilityAttrs();
-        this.__fireStackChangeEvent();
+        this.__fireStackChangeEvent({type:'undostack_redo', undoable:undoable});
         return true;
       }
     }

--- a/editor/componentdropable.dre
+++ b/editor/componentdropable.dre
@@ -65,6 +65,15 @@ SOFTWARE. -->
         }
       }
       
+      // Make a copy of the attrs needed to instantiate this view in a previewer
+      var previewerAttrs = dr.extend({}, attrs);
+      // Push on previewable since all nodes/views in a previewer must be previewable.
+      if (previewerAttrs.with) {
+        previewerAttrs.with += ' previewable';
+      } else {
+        previewerAttrs.with = 'previewable';
+      }
+      
       // Remember which attrs to objectify for the model
       var objectifyAttrs = dr.extend({}, attrs);
       delete objectifyAttrs.class;
@@ -117,12 +126,14 @@ SOFTWARE. -->
       // Mark an instance as "new" so we know it needs serialization.
       instance.__NEW = true;
       
+      // Create undoable and "do" it. The previewinfo is also provided so
+      // previewers receiving messages can instantiate the new node/view.
       if (this.islayout) {
-        actions.do(new dr.editor.createlayoutundoable({target:instance}));
+        actions.do(new dr.editor.createlayoutundoable({target:instance, previewinfo:previewerAttrs}));
       } else if (this.isbehavior) {
-        actions.do(new dr.editor.createbehaviorundoable({target:instance}));
+        actions.do(new dr.editor.createbehaviorundoable({target:instance, previewinfo:previewerAttrs}));
       } else {
-        actions.do(new dr.editor.createundoable({target:instance}));
+        actions.do(new dr.editor.createundoable({target:instance, previewinfo:previewerAttrs}));
         selectionmanager.select(instance);
       }
       

--- a/editor/editable.dre
+++ b/editor/editable.dre
@@ -19,7 +19,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. -->
-<mixin name="editable" with="droptarget"
+<!--/**
+  * @class dr.editable {Editor}
+  * A mixin that provides functionality necessary for views to be manipulated 
+  * by the editor.
+  */-->
+<mixin name="editable" with="droptarget, previewable"
   draggroups="{editable:true}" cursor="move"
 >
   <!--// Class Methods //////////////////////////////////////////////////////-->
@@ -263,26 +268,6 @@ SOFTWARE. -->
     } else {
       return this.super(name, value);
     }
-  </method>
-
-  <method name="restoreAttrToModel" args="attrName">
-    var model = editormodel.getModelNode(this);
-    if (model) {
-      var value = model.attr[attrName];
-      this.setAttribute(attrName, value, false);
-    }
-  </method>
-
-  <method name="pauseConstraints">
-    this.__constraintsPaused = true;
-  </method>
-
-  <method name="resumeConstraints">
-    this.__constraintsPaused = false;
-  </method>
-
-  <method name="getConstraintTemplate" args="attrName, expression">
-    return 'if (this.__constraintsPaused) return; ' + this.super();
   </method>
 
   <method name="moveInFrontOf" args="sibling">

--- a/editor/editor_include.dre
+++ b/editor/editor_include.dre
@@ -20,6 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. -->
 <include href='./keyboarddraggable.dre'/>
+<include href='./previewable.dre'/>
 <include href='./editable.dre'/>
 <include href='./controlhandle.dre'/>
 <include href='./reticle.dre'/>
@@ -56,26 +57,14 @@ SOFTWARE. -->
   <include href='./service_nodes/editormodel.dre'/>
 
   <editor-undostack id="undo">
-    <handler event="onstackchange" args="newIdx">
-      // Send a notification to "previewer" clients once the user stops
-      // making changes.
-      if (this._locked) {
-        this._changeWhileLocked = true;
-      } else {
-        if (this._timerId) clearTimeout(this._timerId);
-        this._timerId = setTimeout(function() {editormodel.notifyPreviewers();}, 2500);
-      }
+    <handler event="onstackchange" args="infoObj">
+      // Send an undo/redo message to the server for every change to the
+      // undo stack. This will allow previewers to keep themselves in sync
+      // with changes during editing.
+      var type = infoObj.type, msg = {type:type};
+      if (type === 'undostack_do') msg.undoable = infoObj.undoable.serialize();
+      dr.teem.bus.send(msg);
     </handler>
-    <method name="lock">
-      this._locked = true;
-    </method>
-    <method name="unlock">
-      this._locked = false;
-      if (this._changeWhileLocked) {
-        this._changeWhileLocked = false;
-        editormodel.notifyPreviewers();
-      }
-    </method>
   </editor-undostack>
 
 

--- a/editor/previewable.dre
+++ b/editor/previewable.dre
@@ -1,0 +1,47 @@
+<!-- The MIT License (MIT)
+
+Copyright ( c ) 2014-2015 Teem2 LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. -->
+<!--/**
+  * @class dr.previewable {Editor}
+  * A mixin that provides functionality necessary for views to respond to 
+  * undo/redo changes in the previewer.
+  */-->
+<mixin name="previewable" requires="resizelayout, alignlayout, wrappinglayout, behavior-scale, behavior-shift, behavior-overborder">
+  <!--// Methods ////////////////////////////////////////////////////////////-->
+  <method name="restoreAttrToModel" args="attrName, model">
+    if (model) {
+      var value = model.attr[attrName];
+      this.setAttribute(attrName, value, false);
+    }
+  </method>
+
+  <method name="pauseConstraints">
+    this.__constraintsPaused = true;
+  </method>
+
+  <method name="resumeConstraints">
+    this.__constraintsPaused = false;
+  </method>
+
+  <method name="getConstraintTemplate" args="attrName, expression">
+    return 'if (this.__constraintsPaused) return; ' + this.super();
+  </method>
+</mixin>

--- a/editor/service_nodes/component_manifest.dre
+++ b/editor/service_nodes/component_manifest.dre
@@ -19,40 +19,42 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. -->
-<node requires="resizelayout, alignlayout, behavior-scale, behavior-shift, behavior-overborder">
+<node>
+  <!-- Important: add required classes to the previewable mixin since the
+       previewer clients will also need access to the components. -->
   <method name="initNode" args="parent, attrs">
     this.super();
     
     // Views
-    this.addComponent({
+    this._addComponent({
       label:'image',
       iconname:'bitmap',
       dropclass:'view',
       dropclassattrs:{width:50, height:50, bgcolor:'#cccccc', instanceattrs:{class:'bitmap', width:50, height:50}}
     });
     
-    this.addComponent({
+    this._addComponent({
       label:'text',
       iconname:'text',
       dropclass:'text',
       dropclassattrs:{text:'text', instanceattrs:{class:'text', text:'text', multiline:true}}
     });
     
-    this.addComponent({
+    this._addComponent({
       label:'rectange',
       iconname:'view',
       dropclass:'view',
       dropclassattrs:{width:50, height:50, bgcolor:'#cccccc', instanceattrs:{class:'view', width:50, height:50, bgcolor:'#cccccc'}}
     });
     
-    this.addComponent({
+    this._addComponent({
       label:'vertical line',
       iconname:'verticalline',
       dropclass:'view',
       dropclassattrs:{width:1, height:'50', bgcolor:'#000000', instanceattrs:{class:'view', width:1, height:'100%', y:'top', bgcolor:'#000000'}}
     });
     
-    this.addComponent({
+    this._addComponent({
       label:'horizontal line',
       iconname:'horizontalline',
       dropclass:'view',
@@ -60,24 +62,25 @@ SOFTWARE. -->
     });
     
     // Layouts
-    this.addLayout('spacedlayout_x', {label:'x layout'}, {class:'spacedlayout', axis:'x'}, true);
-    this.addLayout('spacedlayout_y', {label:'y layout'}, {class:'spacedlayout', axis:'y'});
-    this.addLayout('wrappinglayout_x', {label:'wrap-x layout'}, {class:'wrappinglayout', axis:'x'});
-    this.addLayout('wrappinglayout_y', {label:'wrap-y layout'}, {class:'wrappinglayout', axis:'y'});
-    this.addLayout('resizelayout_x', {label:'resize-x layout'}, {class:'resizelayout', axis:'x'});
-    this.addLayout('resizelayout_y', {label:'resize-y layout'}, {class:'resizelayout', axis:'y'});
-    this.addLayout('alignlayout_x', {label:'align-x layout'}, {class:'alignlayout', align:'center', axis:'x'});
-    this.addLayout('alignlayout_y', {label:'align-y layout'}, {class:'alignlayout', align:'middle', axis:'y'});
-    //this.addLayout('variablelayout', {label:'variable layout'}, {class:'variablelayout'});
-    //this.addLayout('constantlayout', {label:'constant layout'}, {class:'constantlayout'});
+    this._addLayout('spacedlayout_x', {label:'x layout'}, {class:'spacedlayout', axis:'x'}, true);
+    this._addLayout('spacedlayout_y', {label:'y layout'}, {class:'spacedlayout', axis:'y'});
+    this._addLayout('wrappinglayout_x', {label:'wrap-x layout'}, {class:'wrappinglayout', axis:'x'});
+    this._addLayout('wrappinglayout_y', {label:'wrap-y layout'}, {class:'wrappinglayout', axis:'y'});
+    this._addLayout('resizelayout_x', {label:'resize-x layout'}, {class:'resizelayout', axis:'x'});
+    this._addLayout('resizelayout_y', {label:'resize-y layout'}, {class:'resizelayout', axis:'y'});
+    this._addLayout('alignlayout_x', {label:'align-x layout'}, {class:'alignlayout', align:'center', axis:'x'});
+    this._addLayout('alignlayout_y', {label:'align-y layout'}, {class:'alignlayout', align:'middle', axis:'y'});
+    //this._addLayout('variablelayout', {label:'variable layout'}, {class:'variablelayout'});
+    //this._addLayout('constantlayout', {label:'constant layout'}, {class:'constantlayout'});
     
     // Behaviors
-    this.addBehavior('scale', true);
-    this.addBehavior('shift');
-    this.addBehavior('overborder');
+    this._addBehavior('scale', true);
+    this._addBehavior('shift');
+    this._addBehavior('overborder');
   </method>
-  
-  <method name="addLayout" args="key, attrs, instanceAttrs, isNewLine">
+
+  <!-- @private -->
+  <method name="_addLayout" args="key, attrs, instanceAttrs, isNewLine">
     attrs.dropclass = 'bitmap';
     attrs.iconname = key;
     
@@ -91,10 +94,11 @@ SOFTWARE. -->
       instanceattrs:instanceAttrs
     };
     
-    this.addComponent(attrs, isNewLine);
+    this._addComponent(attrs, isNewLine);
   </method>
-  
-  <method name="addBehavior" args="key, isNewLine">
+
+  <!-- @private -->
+  <method name="_addBehavior" args="key, isNewLine">
     var attrs = {
       dropclass: 'bitmap',
       label:key + ' Behavior',
@@ -102,10 +106,11 @@ SOFTWARE. -->
       dropclassattrs:{width:30, height:30, isbehavior:true, src:config.img_root + 'behavior_' + key + '.png', instanceattrs:{class:'behavior-' + key}}
     };
     
-    this.addComponent(attrs, isNewLine);
+    this._addComponent(attrs, isNewLine);
   </method>
   
-  <method name="addComponent" args="attrs, isNewLine">
+  <!-- @private -->
+  <method name="_addComponent" args="attrs, isNewLine">
     attrs.class = 'componentsource';
     if (isNewLine) attrs.layouthint = '{"break":true}';
     this.parent.createChild(attrs);

--- a/editor/service_nodes/editormodel.dre
+++ b/editor/service_nodes/editormodel.dre
@@ -37,7 +37,9 @@ SOFTWARE. -->
     if (this._replicatorchanges && selected) this._showReplicationWarning();
   </handler>
 
-  <handler event="oninit">
+  <method name="initNode" args="parent, attrs">
+    this.super();
+    
     // Extract screen from the query and store it.
     var screenname = 'default',
       query = this._getSearch();
@@ -54,13 +56,13 @@ SOFTWARE. -->
     }
     this.setAttribute('screenname', screenname);
     
+    // Fetch the composition model from the server since that is what we will
+    // be editing.
     var self = this;
-    // rewrite the file to be editable, which will reload this page automatically
     dr.global.requestor.fetch(this._getPath() + '?raw=1').success(
       function(data, status) {
         var parser = new dr.htmlparser();
-        var jsobj = parser.parse(data);
-        self.setAttribute('model', jsobj);
+        self.setAttribute('model', parser.parse(data));
         self.sendEvent('onmodelchange', self);
         
         // Update screenname chooser
@@ -73,14 +75,25 @@ SOFTWARE. -->
         var screennameChooser = dr.sprite.retrieveGlobal('screennamechooser');
         screennameChooser.setAttribute('itemconfig', cfg);
         screennameChooser.setAttribute('label', 'current screen: ' + curName);
+        
+        // Refresh previewer clients
+        // Send the current state of the composition to the server so the previewer clients will refresh
+        if (self.model) {
+          var baseUrl = self._getBaseUrl(),
+            url = baseUrl + (baseUrl.indexOf('?') === -1) ? '?' : '&';
+          url += 'edit=1&notifyPreviewers=1';
+          dr.global.requestor.send(url, JSON.stringify(self.model));
+        }
       }
     );
-  </handler>
+  </method>
 
+  <!-- @private -->
   <method name="_setLocation" args="url">
     window.location = url;
   </method>
 
+  <!-- @private -->
   <method name="_getPath">
     var pathname = window.location.pathname;
     
@@ -89,10 +102,12 @@ SOFTWARE. -->
     return (pathname.startsWith('//') && dr.sprite.platform.browser === 'PhantomJS') ? pathname.substring(1) : pathname;
   </method>
 
+  <!-- @private -->
   <method name="_getSearch">
     return window.location.search;
   </method>
 
+  <!-- @private -->
   <method name="_getBaseUrl">
     return this._getPath() + this._getSearch();
   </method>
@@ -346,20 +361,6 @@ SOFTWARE. -->
         if (newChildModel) return newChildModel;
       }
     }
-  </method>
-
-  <!-- Send the current state of the composition to the server so any
-       clients in "preview" mode can be notified. -->
-  <method name="notifyPreviewers">
-    var baseUrl = this._getBaseUrl(),
-      url = baseUrl + (baseUrl.indexOf('?') === -1) ? '?' : '&';
-    url += 'edit=1&notifyPreviewers=1';
-    
-    var self = this;
-    undo.lock();
-    dr.global.requestor.send(url, JSON.stringify(this.model)).always(
-      function(data, status) {undo.unlock();}
-    );
   </method>
 
   <!-- Save the model changes to the server and reload for editing again. -->

--- a/editor/undo/createbehaviorundoable.dre
+++ b/editor/undo/createbehaviorundoable.dre
@@ -11,10 +11,19 @@
 >
   <!--// Class Methods //////////////////////////////////////////////////////-->
   <method name="refresh" args="targetParent" allocation="class">
-    if (selectionmanager.selectedview === targetParent) {
-      behaviors_panel.refresh(targetParent);
+    // When in the previewer we will need to recheck clickability since
+    // a behavior may have added a mouse handler at runtime and the target
+    // view may not already be clickable.
+    if (dr.sprite.retrieveGlobal('previewer_undostack')) {
+      // Previewer only case
+      targetParent.__checkClickability();
     } else {
-      selectionmanager.select(targetParent);
+      // Editor only case
+      if (selectionmanager.selectedview === targetParent) {
+        behaviors_panel.refresh(targetParent);
+      } else {
+        selectionmanager.select(targetParent);
+      }
     }
   </method>
 

--- a/editor/undo/createlayoutundoable.dre
+++ b/editor/undo/createlayoutundoable.dre
@@ -44,6 +44,16 @@
         CLU.refresh(this._targetParent);
         target.update();
       } else {
+        // Remember initial state of all views effected by the layout so we
+        // can restore them during undo.
+        if (dr.sprite.retrieveGlobal('previewer_undostack')) {
+          var parent = target.parent, 
+            svs = parent.getSubviews(),
+            i = svs.length;
+          CLU._storeModel(parent);
+          while (i) CLU._storeModel(svs[--i]);
+        }
+        
         CLU.refresh(target.parent);
         target.setAttribute('locked', false);
       }
@@ -51,16 +61,22 @@
     
     return retval;
   </method>
-  
+
+
   <!--// Class Methods //////////////////////////////////////////////////////-->
   <method name="refresh" args="targetParent" allocation="class">
-    if (selectionmanager.selectedview === targetParent) {
-      layouts_panel.refresh(targetParent);
+    if (dr.sprite.retrieveGlobal('previewer_undostack')) {
+      // Previewer only case
     } else {
-      selectionmanager.select(targetParent);
+      // Editor only case
+      if (selectionmanager.selectedview === targetParent) {
+        layouts_panel.refresh(targetParent);
+      } else {
+        selectionmanager.select(targetParent);
+      }
     }
   </method>
-  
+
   <method name="restoreManagedViewState" args="undoable" allocation="class">
     var layout = undoable.target,
       svs = layout.getSubviews(),
@@ -70,15 +86,16 @@
       isDomainY = domains.y,
       isDomainW = domains.width,
       isDomainH = domains.height,
-      layouthint;
+      layouthint, model;
     layout.setAttribute('locked', true);
     while (i) {
       sv = svs[--i];
       layouthint = sv.getActualAttribute('layouthint');
-      if (isDomainX || layout.__shouldRestoreForLayoutHint('x', layouthint, null)) sv.restoreAttrToModel('x');
-      if (isDomainW || layout.__shouldRestoreForLayoutHint('width', layouthint, null)) sv.restoreAttrToModel('width');
-      if (isDomainY || layout.__shouldRestoreForLayoutHint('y', layouthint, null)) sv.restoreAttrToModel('y');
-      if (isDomainH || layout.__shouldRestoreForLayoutHint('height', layouthint, null)) sv.restoreAttrToModel('height');
+      model = this._getModel(sv);
+      if (isDomainX || layout.__shouldRestoreForLayoutHint('x', layouthint, null)) sv.restoreAttrToModel('x', model);
+      if (isDomainW || layout.__shouldRestoreForLayoutHint('width', layouthint, null)) sv.restoreAttrToModel('width', model);
+      if (isDomainY || layout.__shouldRestoreForLayoutHint('y', layouthint, null)) sv.restoreAttrToModel('y', model);
+      if (isDomainH || layout.__shouldRestoreForLayoutHint('height', layouthint, null)) sv.restoreAttrToModel('height', model);
     }
     this._restoreManagedParentState(undoable);
     layout.setAttribute('locked', false);
@@ -94,28 +111,56 @@
   <method name="_restoreManagedParentState" args="undoable" allocation="class">
     var layout = undoable.target,
       domains = layout.__getLayoutDomains(),
-      parent = undoable._targetParent || layout.parent;
-    if (domains.x) parent.restoreAttrToModel('width');
-    if (domains.y) parent.restoreAttrToModel('height');
+      parent = undoable._targetParent || layout.parent,
+      model = this._getModel(parent);
+    if (domains.x) parent.restoreAttrToModel('width', model);
+    if (domains.y) parent.restoreAttrToModel('height', model);
   </method>
-  
+
   <method name="restoreSingleManagedViewState" args="view" allocation="class">
-    var layouthint = view.getActualAttribute('layouthint');
+    var layouthint = view.getActualAttribute('layouthint'),
+      model = this._getModel(view);
     
-    if (view.__layoutDomainInUseForView('x') || view.__shouldRestoreForLayoutHint('x', layouthint, null)) view.restoreAttrToModel('x');
-    if (view.__layoutDomainInUseForView('y') || view.__shouldRestoreForLayoutHint('y', layouthint, null)) view.restoreAttrToModel('y');
-    if (view.__layoutDomainInUseForView('width') || view.__shouldRestoreForLayoutHint('width', layouthint, null)) view.restoreAttrToModel('width');
-    if (view.__layoutDomainInUseForView('height') || view.__shouldRestoreForLayoutHint('height', layouthint, null)) view.restoreAttrToModel('height');
+    if (view.__layoutDomainInUseForView('x') || view.__shouldRestoreForLayoutHint('x', layouthint, null)) view.restoreAttrToModel('x', model);
+    if (view.__layoutDomainInUseForView('y') || view.__shouldRestoreForLayoutHint('y', layouthint, null)) view.restoreAttrToModel('y', model);
+    if (view.__layoutDomainInUseForView('width') || view.__shouldRestoreForLayoutHint('width', layouthint, null)) view.restoreAttrToModel('width', model);
+    if (view.__layoutDomainInUseForView('height') || view.__shouldRestoreForLayoutHint('height', layouthint, null)) view.restoreAttrToModel('height', model);
   </method>
-  
+
   <method name="restoreForLayoutHint" args="view, from, to" allocation="class">
-    var AS = dr.AccessorSupport;
+    var AS = dr.AccessorSupport,
+      model = this._getModel(view);
     from = AS.coerce('layouthint', from, 'json');
     to = AS.coerce('layouthint', to, 'json');
     
-    if (view.__shouldRestoreForLayoutHint('x', from, to)) view.restoreAttrToModel('x');
-    if (view.__shouldRestoreForLayoutHint('y', from, to)) view.restoreAttrToModel('y');
-    if (view.__shouldRestoreForLayoutHint('width', from, to)) view.restoreAttrToModel('width');
-    if (view.__shouldRestoreForLayoutHint('height', from, to)) view.restoreAttrToModel('height');
+    if (view.__shouldRestoreForLayoutHint('x', from, to)) view.restoreAttrToModel('x', model);
+    if (view.__shouldRestoreForLayoutHint('y', from, to)) view.restoreAttrToModel('y', model);
+    if (view.__shouldRestoreForLayoutHint('width', from, to)) view.restoreAttrToModel('width', model);
+    if (view.__shouldRestoreForLayoutHint('height', from, to)) view.restoreAttrToModel('height', model);
+  </method>
+
+  <!-- Get the model to use for attribute restoration.
+       @private -->
+  <method name="_getModel" args="view" allocation="class">
+    var editormodel = dr.sprite.retrieveGlobal('editormodel');
+    if (editormodel) {
+      // The editor uses the editor model
+      return editormodel.getModelNode(view);
+    } else {
+      // The previewer uses the restore model stored on each view.
+      return view.__restoreModel;
+    }
+  </method>
+
+  <!-- Store the model to use for attribute restoration. This model must match
+       the JSON model uses in the editormodel.
+       @private -->
+  <method name="_storeModel" args="view" allocation="class">
+    view.__restoreModel = {attr:{
+      x:view.__cfg_x,
+      y:view.__cfg_y,
+      width:view.__cfg_width,
+      height:view.__cfg_height
+    }};
   </method>
 </class>

--- a/editor/undo/editorattrundoable.dre
+++ b/editor/undo/editorattrundoable.dre
@@ -45,7 +45,7 @@
       while (i) layouts[--i].setActualAttribute('locked', false);
     }
     
-    if (isLayout || isBehavior) selectionmanager.select(target.parent);
+    if (!dr.sprite.retrieveGlobal('previewer_undostack') && (isLayout || isBehavior)) selectionmanager.select(target.parent);
     
     return retval;
   </method>
@@ -88,7 +88,7 @@
       while (i) layouts[--i].setActualAttribute('locked', false);
     }
     
-    if (isLayout || isBehavior) selectionmanager.select(target.parent);
+    if (!dr.sprite.retrieveGlobal('previewer_undostack') && (isLayout || isBehavior)) selectionmanager.select(target.parent);
     
     return retval;
   </method>

--- a/lib/dr/dr.js
+++ b/lib/dr/dr.js
@@ -57,6 +57,22 @@ define(function(require, exports, module) {
             prevent the default setAttribute behavior. */
         noop: function() {},
         
+        /** Called from previewers to deserialize undoables. Not intended for
+            use in other contexts, though it may still be useful. */
+        deserialize: function(json) {
+          var objTree = JSON.parse(json),
+            classname = objTree.classname,
+            data = objTree.data;
+            
+          var klass = this.lookupClass(classname);
+          if (klass) {
+              var obj = new klass();
+              if (obj.deserialize) obj.deserialize(data);
+              return obj;
+          }
+          return null;
+        },
+        
         /** Takes a '.' separated string such as "foo.bar.baz" and resolves it
             into the value found at that location relative to a starting scope.
             If no scope is provided global scope is used.

--- a/lib/dr/dreemMaker.js
+++ b/lib/dr/dreemMaker.js
@@ -25,7 +25,7 @@ Instantiates dr classes from a package JSON object.
 */
 define(function(require, exports, module) {
   var maker = exports,
-    dr = require('$LIB/dr/dr.js')
+    dr = require('$LIB/dr/dr.js'),
     JS = require('$LIB/jsclass.js'),
     sprite = require('$SPRITE/sprite.js'),
     acorn = require('$LIB/acorn'),

--- a/lib/dr/view/View.js
+++ b/lib/dr/view/View.js
@@ -875,12 +875,18 @@ define(function(require, exports, module) {
             this.set_sprite(this.createSprite(attrs));
             
             var clickableWasDisabled = attrs.clickable === 'false';
-            this.callSuper(parent, attrs);
-            if (clickableWasDisabled) return;
             
-            var clickableEvents = ['onmousedown', 'onmouseup', 'onmouseover', 'onmouseout', 'onclick']; 
-            for (var i = 0; i < clickableEvents.length; i++) {
-                if (this.hasObservers(clickableEvents[i])) {
+            this.callSuper(parent, attrs);
+            
+            if (!clickableWasDisabled) this.__checkClickability();
+        },
+        
+        /** @private */
+        __checkClickability: function() {
+            var clickableEvents = ['onmousedown', 'onmouseup', 'onmouseover', 'onmouseout', 'onclick'], 
+                i = clickableEvents.length;
+            while (i) {
+                if (this.hasObservers(clickableEvents[--i])) {
                     this.setAttribute('clickable', true);
                     break;
                 }


### PR DESCRIPTION
Implemented new dynamic editing that broadcasts serialized undo/redo
messages over the websocket from the edited composition to the
previewer composition.

The pre-existing mechanim that uses page reloads has been preserved,
but only for an initial reload when the editor loads the raw model.
This is necessary so that the previewer clients will start off in
the same state as the editor.