### PR TITLE
Fix path when requiring DALi Node.js binary on Tizen

### DIFF
--- a/dreemnodejs.js
+++ b/dreemnodejs.js
@@ -377,7 +377,15 @@ console.log('main_file', main_file);
         
         console.log("** loading Dali")
         global.dali = require('./dalinode/dali')(options);
-
+        console.log("** loading Dali")
+	try {
+	    var exists = fs.statSync('/etc/tizen-release').isFile();
+	    console.log('Running Tizen, requiring dali from: /usr/lib/node_modules/npm/node_modules/dali/dali')
+	    global.dali = require('/usr/lib/node_modules/npm/node_modules/dali/dali')(options)
+	} catch (err) {
+	    console.log('Running Ubuntu, requiring dali from ./dalinode/dali')
+	    global.dali = require('.dalinode/dali')(options)
+	}
 		// Show/hide a loading page
 		global.show_loading_page = function() {
 			var sz = dali.stage.getSize();


### PR DESCRIPTION
On Tizen we need to use the path /usr/lib/node_modules/npm/node_modules/dali/dali when requiring DALi binary from Node.js. This change will test if we are on Tizen by looking for the /etc/tizen-release file. If the file is found, the Tizen path is used for the require.