### PR TITLE
Dreem-104070755 Attributes panel enhancements

### DIFF
--- a/classes/alignlayout.dre
+++ b/classes/alignlayout.dre
@@ -30,7 +30,7 @@
     * A value of 'y' will restrict align values to 'top', 'middle' and 'bottom'.
     * An empty/null value will not restrict the align values.
     */-->
-  <attribute name="axis" type="string" value=""></attribute>
+  <attribute name="axis" type="string" value="" category="layout"></attribute>
   <setter name="axis" args="axis">
     @setActual('axis', axis, 'string', '')
     @setAttribute('align', @align)
@@ -42,7 +42,7 @@
     * 'left', 'center', 'right' for horizontal alignment and 'top', 'middle' 
     * and 'bottom' for vertical alignment.
     */-->
-  <attribute name="align" type="string" value="middle"></attribute>
+  <attribute name="align" type="string" value="middle" category="layout"></attribute>
   <setter name="align" args="align">
     if @align isnt align
       # Stop monitoring since we may end up changing the axis. This needs to
@@ -229,7 +229,4 @@
   
   <attribute name="hiddenattrs" type="expression" value="{attribute:true, value:true, reverse:true}" allocation="class"/>
   <attribute name="readonlyattrs" type="expression" value="{axis:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{axis:-2, name:-1, align:1, updateparent:2, speed:3}"
-  />
 </class>

--- a/classes/alignlayout.dre
+++ b/classes/alignlayout.dre
@@ -42,7 +42,7 @@
     * 'left', 'center', 'right' for horizontal alignment and 'top', 'middle' 
     * and 'bottom' for vertical alignment.
     */-->
-  <attribute name="align" type="string" value="middle" category="layout"></attribute>
+  <attribute name="align" type="string" value="middle" category="layout" weight="1"></attribute>
   <setter name="align" args="align">
     if @align isnt align
       # Stop monitoring since we may end up changing the axis. This needs to

--- a/classes/behavior/overborder.dre
+++ b/classes/behavior/overborder.dre
@@ -5,11 +5,11 @@
 
 
 <class name="behavior-overborder" extends="node" with="behavior-behavior">
-  <attribute name="thickness" type="number" value="5"/>
-  <attribute name="opacity" type="number" value="1"/>
-  <attribute name="color" type="color" value="#f8f8f8"/>
-  <attribute name="overspeed" type="number" value="400"/>
-  <attribute name="outspeed" type="number" value="400"/>
+  <attribute name="color" type="color" value="#f8f8f8" weight="1"/>
+  <attribute name="thickness" type="number" value="5" editorname="Width"  weight="1"/>
+  <attribute name="opacity" type="number" value="1"  weight="2"/>
+  <attribute name="overspeed" type="number" value="400" editorname="IN Duration" weight="3"/>
+  <attribute name="outspeed" type="number" value="400" editorname="OUT Duration" weight="4"/>
 
   <handler name="show" event="onmouseover" reference="this.parent">
     // Check for parent since over/out events will still occur when this

--- a/classes/behavior/scale.dre
+++ b/classes/behavior/scale.dre
@@ -5,10 +5,10 @@
 
 
 <class name="behavior-scale" extends="node" with="behavior-behavior">
-  <attribute name="magnitude" type="number" value="2"/>
-  <attribute name="scaleinduration" type="number" value="800"/>
-  <attribute name="scaleoutduration" type="number" value="400"/>
-  <attribute name="bringtofront" type="boolean" value="true"/>
+  <attribute name="magnitude" type="number" value="2" weight="1"/>
+  <attribute name="scaleinduration" type="number" value="800" editorname="IN Duration" weight="2"/>
+  <attribute name="scaleoutduration" type="number" value="400" editorname="OUT Duration" weight="3"/>
+  <attribute name="bringtofront" type="boolean" value="true" editorname="Bring to Front" weight="1"/>
 
   <handler name="show" event="onmouseover" reference="this.parent">
     var parent = this.parent,

--- a/classes/behavior/shift.dre
+++ b/classes/behavior/shift.dre
@@ -5,8 +5,8 @@
 
 
 <class name="behavior-shift" extends="node" with="behavior-behavior">
-  <attribute name="xshift" type="number" value="0"/>
-  <attribute name="yshift" type="number" value="20"/>
+  <attribute name="xshift" type="number" value="0" editorname="Shift by X"/>
+  <attribute name="yshift" type="number" value="20" editorname="Shift by Y"/>
 
   <method name="initNode" args="parent, attrs">
     this.__shifted = false;

--- a/classes/bitmap.dre
+++ b/classes/bitmap.dre
@@ -32,7 +32,7 @@
       * @event onerror 
       * Fired when there is an error loading the bitmap
       */-->
-  <attribute name="src" type="string" value=""/>
+  <attribute name="src" type="string" value="" editorname="URL",/>
 
   <!--/**
       * @attribute {String} [stretches=false]
@@ -110,7 +110,4 @@
   
   <!--// Editor //-->
   <attribute name="hiddenattrs" type="expression" value="{naturalsize:true, window:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{src:1, stretches:2, repeat:100}"
-  />
 </class>

--- a/classes/bitmap.dre
+++ b/classes/bitmap.dre
@@ -46,7 +46,7 @@
       * "none" will display the image at its natural size but without resizing 
       * the view as the naturalsize attribute does.
       */-->
-  <attribute name="stretches" type="string" value="false"/>
+  <attribute name="stretches" type="string" value="false" editorname="Content Stretch"/>
 
   <!--/**
       * @attribute {Boolean} [naturalsize=false]

--- a/classes/constantlayout.dre
+++ b/classes/constantlayout.dre
@@ -54,7 +54,7 @@
     * The speed of an animated update of the managed views. If 0 no animation
     * will be performed
     */-->
-  <attribute name="speed" type="positivenumber" value="0"></attribute>
+  <attribute name="speed" type="positivenumber" value="0" weight="200" editorname="Anim. Duration"></attribute>
 
   <!--/**
     * @method update

--- a/classes/dataset.dre
+++ b/classes/dataset.dre
@@ -85,13 +85,13 @@
     * @attribute {String} url
     * The url to load JSON data from.
     */-->
-  <attribute name="url" type="string" value=""></attribute>
+  <attribute name="url" type="string" value="" editorname="URL"></attribute>
 
   <!--/**
     * @attribute {Boolean} [async=true]
     * If true, parse json in a worker thread
     */-->
-  <attribute name="async" value="true" type="boolean"></attribute>
+  <attribute name="async" value="true" type="boolean" editorname="Asynchronous"></attribute>
 
   <setter name="$textcontent" args="textcontent">
     textcontent = textcontent?.trim()

--- a/classes/replicator.dre
+++ b/classes/replicator.dre
@@ -164,13 +164,13 @@
     * @attribute {String} [path=]
     * If set, a {@link #datapath datapath} will be used to look up the value.
     */-->
-  <attribute name="datapath" value="" type="string"/>
+  <attribute name="datapath" value="" type="string" editorname="Data Path"/>
 
   <!--/**
     * @attribute {String} classname (required)
     * The name of the class to be replicated.
     */-->
-  <attribute name="classname" value="" type="string"/>
+  <attribute name="classname" value="" type="string" editorname="Class Name"/>
 
   <handler event="ondestroy" method="clear"/>
 

--- a/classes/resizelayout.dre
+++ b/classes/resizelayout.dre
@@ -165,7 +165,4 @@
   
   <attribute name="hiddenattrs" type="expression" value="{attribute:true, value:true, updateparent:true}" allocation="class"/>
   <attribute name="readonlyattrs" type="expression" value="{axis:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{axis:-2, name:-1, inset:1, spacing:2, outset:3, reverse:4, updateparent:5, speed:6}"
-  />
 </class>

--- a/classes/spacedlayout.dre
+++ b/classes/spacedlayout.dre
@@ -58,14 +58,14 @@
     * @attribute {Number} [spacing=0]
     * The spacing between views.
     */-->
-  <attribute name="spacing" type="number" value="0" category="layout"></attribute>
+  <attribute name="spacing" type="number" value="0" category="layout" weight="2"></attribute>
   <handler event="onspacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [outset=0]
     * Space after the last view. Only used when updateparent is true.
     */-->
-  <attribute name="outset" type="number" value="0" category="layout"></attribute>
+  <attribute name="outset" type="number" value="0" category="layout" weight="3"></attribute>
   <handler event="onoutset" method="update"></handler>
   
   <!--/**
@@ -73,7 +73,7 @@
     * Space before the first view. This is an alias for the "value" attribute.
     * attribute.
     */-->
-  <attribute name="inset" type="number" value="0" category="layout"></attribute>
+  <attribute name="inset" type="number" value="0" category="layout" weight="3"></attribute>
   <setter name="inset" args="inset">
     # An alias for value.
     @setActual('inset', inset, 'number', 0)
@@ -87,7 +87,7 @@
     * will orient them vertically. This is an alias for the "attribute" 
     * attribute.
     */-->
-  <attribute name="axis" type="string" value="x" category="layout"></attribute>
+  <attribute name="axis" type="string" value="x" category="layout" weight="1"></attribute>
   <setter name="axis" args="axis">
     # An alias for attribute.
     @setActual('axis', axis, 'string', 'x')

--- a/classes/spacedlayout.dre
+++ b/classes/spacedlayout.dre
@@ -58,14 +58,14 @@
     * @attribute {Number} [spacing=0]
     * The spacing between views.
     */-->
-  <attribute name="spacing" type="number" value="0"></attribute>
+  <attribute name="spacing" type="number" value="0" category="layout"></attribute>
   <handler event="onspacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [outset=0]
     * Space after the last view. Only used when updateparent is true.
     */-->
-  <attribute name="outset" type="number" value="0"></attribute>
+  <attribute name="outset" type="number" value="0" category="layout"></attribute>
   <handler event="onoutset" method="update"></handler>
   
   <!--/**
@@ -73,7 +73,7 @@
     * Space before the first view. This is an alias for the "value" attribute.
     * attribute.
     */-->
-  <attribute name="inset" type="number" value="0"></attribute>
+  <attribute name="inset" type="number" value="0" category="layout"></attribute>
   <setter name="inset" args="inset">
     # An alias for value.
     @setActual('inset', inset, 'number', 0)
@@ -87,7 +87,7 @@
     * will orient them vertically. This is an alias for the "attribute" 
     * attribute.
     */-->
-  <attribute name="axis" type="string" value="x"></attribute>
+  <attribute name="axis" type="string" value="x" category="layout"></attribute>
   <setter name="axis" args="axis">
     # An alias for attribute.
     @setActual('axis', axis, 'string', 'x')
@@ -201,7 +201,4 @@
   
   <attribute name="hiddenattrs" type="expression" value="{attribute:true, value:true}" allocation="class"/>
   <attribute name="readonlyattrs" type="expression" value="{axis:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{axis:-2, name:-1, inset:1, spacing:2, outset:3, reverse:4, updateparent:5, speed:6}"
-  />
 </class>

--- a/classes/text.dre
+++ b/classes/text.dre
@@ -72,7 +72,7 @@
         * @attribute {Number} [fontsize]
         * The size of the font in pixels.
         */-->
-  <attribute name="fontsize" type="number" value=""/>
+  <attribute name="fontsize" type="number" value="" category="text" weight="10" editorname="Size"/>
   <setter name="fontsize" args="v">
     if @setActual('fontsize', v, 'number', '')
       if @inited then @sizeToPlatform()
@@ -82,7 +82,7 @@
         * @attribute {Number} [fontfamily=""]
         * The name of the font family to use, e.g. "Helvetica"  Include multiple fonts on a line, separated by commas.
         */-->
-  <attribute name="fontfamily" type="string" value=""/>
+  <attribute name="fontfamily" type="string" value="" category="text" weight="10" editorname="Font"/>
   <setter name="fontfamily" args="v">
     if @setActual('fontfamily', v, 'string', '')
       if @inited then @sizeToPlatform()
@@ -93,7 +93,7 @@
         * Align text within its bounds. Supported values are 
         * 'left', 'right', 'center' and 'inherit'.
         */-->
-  <attribute name="textalign" type="string" value=""/>
+  <attribute name="textalign" type="string" value="" category="text" weight="40" editorname="Text Align"/>
   <setter name="textalign" args="v">
     if @setActual('textalign', v, 'string', '')
       if @inited then @sizeToPlatform()
@@ -103,7 +103,7 @@
         * @attribute {Boolean} [bold=false]
         * Use bold text.
         */-->
-  <attribute name="bold" type="boolean" value="false"/>
+  <attribute name="bold" type="boolean" value="false" category="text" weight="30"/>
   <setter name="bold" args="v">
     if @setActual('bold', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -113,7 +113,7 @@
         * @attribute {Boolean} [italic=false]
         * Use italic text.
         */-->
-  <attribute name="italic" type="boolean" value="false"/>
+  <attribute name="italic" type="boolean" value="false" category="text" weight="30"/>
   <setter name="italic" args="v">
     if @setActual('italic', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -123,7 +123,7 @@
         * @attribute {Boolean} [smallcaps=false]
         * Use small caps style.
         */-->
-  <attribute name="smallcaps" type="boolean" value="false"/>
+  <attribute name="smallcaps" type="boolean" value="false" category="text" weight="30"/>
   <setter name="smallcaps" args="v">
     if @setActual('smallcaps', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -133,7 +133,7 @@
         * @attribute {Boolean} [underline=false]
         * Draw and underline under text (note, is incompatible with dr.text#strike)
         */-->
-  <attribute name="underline" type="boolean" value="false"/>
+  <attribute name="underline" type="boolean" value="false" category="text" weight="30"/>
   <setter name="underline" args="v">
     if @setActual('underline', v, 'boolean', false)
       if @underline and @strike then @setSimpleActual('strike', false, true)
@@ -144,7 +144,7 @@
         * @attribute {Boolean} [strike=false]
         * Draw and strike-through the text (note, is incompatible with dr.text#underline)
         */-->
-  <attribute name="strike" type="boolean" value="false"/>
+  <attribute name="strike" type="boolean" value="false" category="text" weight="30"/>
   <setter name="strike" args="v">
     if @setActual('strike', v, 'boolean', false)
       if @strike and @underline then @setSimpleActual('underline', false, true)
@@ -155,7 +155,7 @@
         * @attribute {Boolean} [multiline=false]
         * Determines how line breaks within the text are handled.
         */-->
-  <attribute name="multiline" type="boolean" value="false"/>
+  <attribute name="multiline" type="boolean" value="false" category="text" weight="1"/>
   <setter name="multiline" args="v">
     if @setActual('multiline', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -166,7 +166,7 @@
         * Determines if ellipsis shouls be shown or not. Only works when
         * multiline is false.
         */-->
-  <attribute name="ellipsis" type="boolean" value="false"/>
+  <attribute name="ellipsis" type="boolean" value="false" category="text" weight="30"/>
   <setter name="ellipsis" args="v">
     if @setActual('ellipsis', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -176,13 +176,13 @@
         * @attribute {String} [text=""]
         * The contents of this input text field
         */-->
-  <attribute name="text" type="string" value=""/>
+  <attribute name="text" type="string" value="" category="text"/>
   <setter name="text" args="v">
     if @setActual('text', @format(v), 'string', '')
       if @inited then @sizeToPlatform()
   </setter>
 
-  <attribute name="editable" type="boolean" value="false"/>
+  <attribute name="editable" type="boolean" value="false" category="text"/>
   <setter name="editable" args="v">
     if @setActual('editable', v, 'boolean', false)
       if @editable
@@ -260,7 +260,4 @@
   
   <!--// Editor //-->
   <attribute name="hiddenattrs" type="expression" value="{editable:true, clip:true, scrollable:true, underline:true, strike:true, smallcaps:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{name:-1, text:50, color:51, fontfamily:52, fontsize:53, bold:54, italic:55, multiline:200, ellipsis:201, smallcaps:210, underline:211, strike:212}"
-  />
 </class>

--- a/classes/text.dre
+++ b/classes/text.dre
@@ -123,7 +123,7 @@
         * @attribute {Boolean} [smallcaps=false]
         * Use small caps style.
         */-->
-  <attribute name="smallcaps" type="boolean" value="false" category="text" weight="30"/>
+  <attribute name="smallcaps" type="boolean" value="false" category="text" weight="31"/>
   <setter name="smallcaps" args="v">
     if @setActual('smallcaps', v, 'boolean', false)
       if @inited then @sizeToPlatform()
@@ -133,7 +133,7 @@
         * @attribute {Boolean} [underline=false]
         * Draw and underline under text (note, is incompatible with dr.text#strike)
         */-->
-  <attribute name="underline" type="boolean" value="false" category="text" weight="30"/>
+  <attribute name="underline" type="boolean" value="false" category="text" weight="31"/>
   <setter name="underline" args="v">
     if @setActual('underline', v, 'boolean', false)
       if @underline and @strike then @setSimpleActual('strike', false, true)
@@ -144,7 +144,7 @@
         * @attribute {Boolean} [strike=false]
         * Draw and strike-through the text (note, is incompatible with dr.text#underline)
         */-->
-  <attribute name="strike" type="boolean" value="false" category="text" weight="30"/>
+  <attribute name="strike" type="boolean" value="false" category="text" weight="31"/>
   <setter name="strike" args="v">
     if @setActual('strike', v, 'boolean', false)
       if @strike and @underline then @setSimpleActual('underline', false, true)
@@ -166,7 +166,7 @@
         * Determines if ellipsis shouls be shown or not. Only works when
         * multiline is false.
         */-->
-  <attribute name="ellipsis" type="boolean" value="false" category="text" weight="30"/>
+  <attribute name="ellipsis" type="boolean" value="false" category="text" weight="31"/>
   <setter name="ellipsis" args="v">
     if @setActual('ellipsis', v, 'boolean', false)
       if @inited then @sizeToPlatform()

--- a/classes/variablelayout.dre
+++ b/classes/variablelayout.dre
@@ -100,7 +100,7 @@
     * implementation is to resize the parent to fit the newly layed out child 
     * views.
     */-->
-  <attribute name="updateparent" type="boolean" value="false"></attribute>
+  <attribute name="updateparent" type="boolean" value="false" category="layout"></attribute>
   <handler event="onupdateparent" method="update"></handler>
 
   <!--/**
@@ -111,7 +111,7 @@
     * right to left instead of left to right, bottom to top instead of top to
     * bottom, etc.
     */-->
-  <attribute name="reverse" type="boolean" value="false"></attribute>
+  <attribute name="reverse" type="boolean" value="false" category="layout"></attribute>
   <handler event="onreverse" method="update"></handler>
 
   <!--/**

--- a/classes/variablelayout.dre
+++ b/classes/variablelayout.dre
@@ -100,7 +100,7 @@
     * implementation is to resize the parent to fit the newly layed out child 
     * views.
     */-->
-  <attribute name="updateparent" type="boolean" value="false" category="layout"></attribute>
+  <attribute name="updateparent" type="boolean" value="false" category="layout" weight="100" editorname="Update Parent"></attribute>
   <handler event="onupdateparent" method="update"></handler>
 
   <!--/**
@@ -111,7 +111,7 @@
     * right to left instead of left to right, bottom to top instead of top to
     * bottom, etc.
     */-->
-  <attribute name="reverse" type="boolean" value="false" category="layout"></attribute>
+  <attribute name="reverse" type="boolean" value="false" category="layout" weight="10" editorname="Reverse Order"></attribute>
   <handler event="onreverse" method="update"></handler>
 
   <!--/**

--- a/classes/wrappinglayout.dre
+++ b/classes/wrappinglayout.dre
@@ -61,21 +61,21 @@
     * @attribute {Number} [spacing=0]
     * The spacing between views.
     */-->
-  <attribute name="spacing" type="number" value="0" category="layout"></attribute>
+  <attribute name="spacing" type="number" value="0" category="layout" weight="2"></attribute>
   <handler event="onspacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [outset=0]
     * Space after the last view.
     */-->
-  <attribute name="outset" type="number" value="0" category="layout"></attribute>
+  <attribute name="outset" type="number" value="0" category="layout" weight="3"></attribute>
   <handler event="onoutset" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [inset=0]
     * Space before the first view. This is an alias for the "value" attribute.
     */-->
-  <attribute name="inset" type="number" value="0" category="layout"></attribute>
+  <attribute name="inset" type="number" value="0" category="layout" weight="3"></attribute>
   <setter name="inset" args="inset">
     # An alias for value.
     @setActual('inset', inset, 'number', 0)
@@ -86,28 +86,28 @@
     * @attribute {Number} [linespacing=0]
     * The spacing between each line of views.
     */-->
-  <attribute name="linespacing" type="number" value="0" category="layout"></attribute>
+  <attribute name="linespacing" type="number" value="0" category="layout" editorname="Line Spacing" weight="5"></attribute>
   <handler event="onlinespacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [lineoutset=0]
     * Space after the last line of views. Only used when updateparent is true.
     */-->
-  <attribute name="lineoutset" type="number" value="0" category="layout"></attribute>
+  <attribute name="lineoutset" type="number" value="0" category="layout" editorname="Line Outset" weight="6"></attribute>
   <handler event="onlineoutset" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [lineinset=0]
     * Space before the first line of views.
     */-->
-  <attribute name="lineinset" type="number" value="0" category="layout"></attribute>
+  <attribute name="lineinset" type="number" value="0" category="layout" editorname="Line Inset" weight="6"></attribute>
   <handler event="onlineinset" method="update"></handler>
   
   <!--/**
     * @attribute {boolean} [justify=false]
     * Justifies lines/columns
     */-->
-  <attribute name="justify" type="boolean" value="false" category="layout"></attribute>
+  <attribute name="justify" type="boolean" value="false" category="layout" weight="10"></attribute>
   <handler event="onjustify" method="update"></handler>
   
   <!--/**
@@ -116,7 +116,7 @@
     * justification is true this has no effect except on a line or column that
     * has only one item.
     */-->
-  <attribute name="align" type="string" value="left" category="layout"></attribute>
+  <attribute name="align" type="string" value="left" category="layout" weight="1"></attribute>
   <handler event="onalign" method="update"></handler>
   
   <!--/**
@@ -126,7 +126,7 @@
     * none, no line alignment will be performed which means transformed views
     * may overlap preceeding lines.
     */-->
-  <attribute name="linealign" type="string" value="none" category="layout"></attribute>
+  <attribute name="linealign" type="string" value="none" category="layout" editorname="Line Align" weight="4"></attribute>
   <handler event="onlinealign" method="update"></handler>
   <setter name="linealign" args="linealign">
     switch linealign

--- a/classes/wrappinglayout.dre
+++ b/classes/wrappinglayout.dre
@@ -61,21 +61,21 @@
     * @attribute {Number} [spacing=0]
     * The spacing between views.
     */-->
-  <attribute name="spacing" type="number" value="0"></attribute>
+  <attribute name="spacing" type="number" value="0" category="layout"></attribute>
   <handler event="onspacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [outset=0]
     * Space after the last view.
     */-->
-  <attribute name="outset" type="number" value="0"></attribute>
+  <attribute name="outset" type="number" value="0" category="layout"></attribute>
   <handler event="onoutset" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [inset=0]
     * Space before the first view. This is an alias for the "value" attribute.
     */-->
-  <attribute name="inset" type="number" value="0"></attribute>
+  <attribute name="inset" type="number" value="0" category="layout"></attribute>
   <setter name="inset" args="inset">
     # An alias for value.
     @setActual('inset', inset, 'number', 0)
@@ -86,28 +86,28 @@
     * @attribute {Number} [linespacing=0]
     * The spacing between each line of views.
     */-->
-  <attribute name="linespacing" type="number" value="0"></attribute>
+  <attribute name="linespacing" type="number" value="0" category="layout"></attribute>
   <handler event="onlinespacing" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [lineoutset=0]
     * Space after the last line of views. Only used when updateparent is true.
     */-->
-  <attribute name="lineoutset" type="number" value="0"></attribute>
+  <attribute name="lineoutset" type="number" value="0" category="layout"></attribute>
   <handler event="onlineoutset" method="update"></handler>
   
   <!--/**
     * @attribute {Number} [lineinset=0]
     * Space before the first line of views.
     */-->
-  <attribute name="lineinset" type="number" value="0"></attribute>
+  <attribute name="lineinset" type="number" value="0" category="layout"></attribute>
   <handler event="onlineinset" method="update"></handler>
   
   <!--/**
     * @attribute {boolean} [justify=false]
     * Justifies lines/columns
     */-->
-  <attribute name="justify" type="boolean" value="false"></attribute>
+  <attribute name="justify" type="boolean" value="false" category="layout"></attribute>
   <handler event="onjustify" method="update"></handler>
   
   <!--/**
@@ -116,7 +116,7 @@
     * justification is true this has no effect except on a line or column that
     * has only one item.
     */-->
-  <attribute name="align" type="string" value="left"></attribute>
+  <attribute name="align" type="string" value="left" category="layout"></attribute>
   <handler event="onalign" method="update"></handler>
   
   <!--/**
@@ -126,7 +126,7 @@
     * none, no line alignment will be performed which means transformed views
     * may overlap preceeding lines.
     */-->
-  <attribute name="linealign" type="string" value="none"></attribute>
+  <attribute name="linealign" type="string" value="none" category="layout"></attribute>
   <handler event="onlinealign" method="update"></handler>
   <setter name="linealign" args="linealign">
     switch linealign
@@ -148,7 +148,7 @@
     * the right of the preceding column. This is an alias for the "attribute" 
     * attribute.
     */-->
-  <attribute name="axis" type="string" value="x"></attribute>
+  <attribute name="axis" type="string" value="x" category="layout"></attribute>
   <setter name="axis" args="axis">
     # An alias for attr.
     @setActual('axis', axis, 'string', 'x')
@@ -435,7 +435,4 @@
   
   <attribute name="hiddenattrs" type="expression" value="{attribute:true, value:true}" allocation="class"/>
   <attribute name="readonlyattrs" type="expression" value="{axis:true}" allocation="class"/>
-  <attribute name="attrimportance" type="expression" allocation="class"
-    value="{axis:-2, name:-1, inset:1, spacing:2, outset:3, lineinset:4, linespacing:5, lineoutset:6, align:7, linealign:8, justify:9, reverse:10, updateparent:11, speed:12}"
-  />
 </class>

--- a/editor/attributeeditor.dre
+++ b/editor/attributeeditor.dre
@@ -378,8 +378,14 @@ either express or implied. See the License for the specific language governing p
         self._checkActualIsDifferent();
       });
     }
-    
-    this.label.setActualAttribute('text', targetAttrName);
+
+    var labelText = targetAttrName;
+    if (this.data && this.data.editorname) {
+      labelText = this.data.editorname;
+    }
+    labelText = labelText.charAt(0).toUpperCase() + labelText.slice(1)
+
+    this.label.setActualAttribute('text', labelText);
   </method>
   
   <method name="_checkActualIsDifferent">

--- a/editor/attributeeditor.dre
+++ b/editor/attributeeditor.dre
@@ -336,6 +336,7 @@ either express or implied. See the License for the specific language governing p
           attrs.multiline = true;
           attrs.wrap = false;
           attrs.height = 'auto';
+
         } else if (targetAttrName === 'fontfamily') {
           attrs.class = 'fonteditor'
           break;
@@ -347,6 +348,11 @@ either express or implied. See the License for the specific language governing p
           attrs.bgcolor = 'transparent';
           attrs.bordercolor = 'transparent';
         }
+        var aval = target.getAttribute(targetAttrName);
+        if (typeof(aval) === 'string' && /^\$\{.*\}$/.test(aval)) {
+          attrs.color = 'green'
+        }
+
         break;
     }
     

--- a/editor/attributeeditor.dre
+++ b/editor/attributeeditor.dre
@@ -399,6 +399,6 @@ either express or implied. See the License for the specific language governing p
     actual.setActualAttribute('visible', '' + this.field.value !== actual.text);
   </method>
 
-  <editor_text name="label" width="${config.attribute_label_width}" y="3" textalign="right"/>
+  <editor_text name="label" width="${config.attribute_label_width}" y="3" textalign="right" color="#999"/>
   <editor_text name="actual" x="${this.parent.innerwidth - this.width - 4}" y="3" width="60"/><!-- 4 pixel spacing -->
 </class>

--- a/editor/editable.dre
+++ b/editor/editable.dre
@@ -14,7 +14,13 @@ either express or implied. See the License for the specific language governing p
 >
   <!--// Class Methods //////////////////////////////////////////////////////-->
   <method name="comparator" args="a, b" allocation="class">
-    if (b.name > a.name) {
+    var aweight = parseInt(a.weight || 0);
+    var bweight = parseInt(b.weight || 0);
+    if (aweight > bweight) {
+      return 1;
+    } else if (bweight > aweight) {
+      return -1;
+    } else if (b.name > a.name) {
       return -1;
     } else if (a.name > b.name) {
       return 1;

--- a/editor/editable.dre
+++ b/editor/editable.dre
@@ -14,21 +14,12 @@ either express or implied. See the License for the specific language governing p
 >
   <!--// Class Methods //////////////////////////////////////////////////////-->
   <method name="comparator" args="a, b" allocation="class">
-    var aimport = a.importance || 99999,
-      bimport = b.importance || 99999;
-    if (bimport === aimport) {
-      if (b.name > a.name) {
-        return -1;
-      } else if (a.name > b.name) {
-        return 1;
-      }
-    } else if (bimport > aimport) {
+    if (b.name > a.name) {
       return -1;
-    } else if (aimport > bimport) {
+    } else if (a.name > b.name) {
       return 1;
-    } else {
-      return 0;
     }
+    return 0;
   </method>
 
 
@@ -325,22 +316,10 @@ either express or implied. See the License for the specific language governing p
 
   <!--// Details Panel Support //-->
   <method name="getAttrsListForDetails">
-    return this._getAttrsListForDetails(null, config.more_threshold);
-  </method>
-  
-  <method name="getMoreAttrsListForDetails">
-    return this._getAttrsListForDetails(config.more_threshold, null);
-  </method>
-  
-  <method name="getAllAttrsListForDetails">
-    return this._getAttrsListForDetails(null, null);
-  </method>
-  
-  <method name="_getAttrsListForDetails" args="lowerLimit, upperLimit">
     // Get Attributes. Pull from ancestors and build list of all attributes.
     var klass = this.klass, ancestors = klass.ancestors(),
       attrMap = {}, attrs = [],
-      key, value, attr, importance,
+      key, value, attr,
       i = 6, // 6 skips over some of the base classes and the editor mixin.
       len = ancestors.length;
     
@@ -371,8 +350,7 @@ either express or implied. See the License for the specific language governing p
     } else {
       // Filter attrs for class
       var hiddenattrs = klass.hiddenattrs,
-        readonlyattrs = klass.readonlyattrs,
-        attrimportance = klass.attrimportance;
+        readonlyattrs = klass.readonlyattrs;
       
       if (hiddenattrs) {
         i = attrs.length;
@@ -389,31 +367,6 @@ either express or implied. See the License for the specific language governing p
           if (readonlyattrs[attr.name]) attr.readonly = true;
         }
       }
-      
-      if (attrimportance) {
-        i = attrs.length;
-        while (i) {
-          attr = attrs[--i];
-          if (attrimportance[attr.name] != null) attr.importance = attrimportance[attr.name];
-        }
-      }
-    }
-    
-    //// Filter By Importance ////
-    lowerLimit = lowerLimit == null ? -99999999 : lowerLimit;
-    upperLimit = upperLimit == null ? 99999999 : upperLimit;
-    
-    // Unspecified importances will be at the end of the non-more section.
-    var unspecifiedImportance = config.more_threshold - 1;
-    
-    i = attrs.length;
-    while (i) {
-      attr = attrs[--i];
-      
-      importance = attr.importance;
-      if (importance == null) importance = unspecifiedImportance;
-      
-      if (lowerLimit > importance || importance >= upperLimit) attrs.splice(i, 1);
     }
     
     //// Sort Attributes ////

--- a/editor/editor_include.dre
+++ b/editor/editor_include.dre
@@ -945,20 +945,7 @@ either express or implied. See the License for the specific language governing p
                   var categoryName = catname.charAt(0).toUpperCase() + catname.slice(1);
                   orderedcategories.push({
                     name:categoryName,
-                    items:catitems.sort(function(a,b){
-                      var aweight = parseInt(a.weight || 0);
-                      var bweight = parseInt(b.weight || 0);
-                      if (aweight > bweight) {
-                        return 1;
-                      } else if (bweight > aweight) {
-                        return -1;
-                      } else if (b.name > a.name) {
-                        return -1;
-                      } else if (a.name > b.name) {
-                        return 1;
-                      }
-                      return 0;
-                    })
+                    items:catitems.sort(dr.editable.comparator)
                   })
                 }
               }

--- a/editor/editor_include.dre
+++ b/editor/editor_include.dre
@@ -902,73 +902,87 @@ either express or implied. See the License for the specific language governing p
               if (isParent) this.speed = 0;
             </method>
           </spacedlayout>
-          <replicator classname="attributeeditor">
-            <handler event="ondelayedselected" args="selected" reference="selectionmanager">
-              this.setAttribute('data', selected ? selected.getAttrsListForDetails() : []);
-            </handler>
-          </replicator>
-        </view>
-        
-        <!-- More attrs subpanel. -->
-        <view width="100%">
-          <attribute name="selected" type="boolean" value="false"/>
-          <handler event="onselected" args="selected">
-            var header = this.header;
-            header.updateUI();
-            header.setActualAttribute('text', (selected ? '▼' : '▶') + " more");
-            
-            this.updateHeight();
-          </handler>
-          
-          <handler name="updateHeight" event="ondelayedselected" reference="selectionmanager">
-            var animAttrs = {attribute:'height', to:0, duration:500};
-            if (selectionmanager.selected) {
-              var svs = this.content.getSubviews();
-              if (this.selected) {
-                var lastChild = svs[svs.length - 1];
-                animAttrs.to = lastChild ? lastChild.y + lastChild.height + this.header.height + 5 : 0;
-              } else {
-                animAttrs.to = svs.length > 0 ? this.header.height : 0;
+          <handler event="ondelayedselected" args="selected" reference="selectionmanager">
+            var attrs = selected ? selected.getAttrsListForDetails() : [];
+            var categories = {};
+            var orderedcategories = [];
+            if (attrs && attrs.length) {
+              var i;
+              for (i = 0; i < attrs.length; i++) {
+                var attr = attrs[i];
+                var category = attr.category;
+                if (!category) {
+                  if (attr.target) {
+                    if (attr.target.$tagname && attr.target.$tagname != 'editable') {
+                      category = attr.target.$tagname;
+                    } else {
+                      category = attr.target.klass.__displayName;
+                    }
+                  } else {
+                    category = 'properties';
+                  }
+                }
+
+                var cats = categories[category];
+                if (!Array.isArray(cats)) {
+                  cats = []
+                  categories[category] = cats
+                }
+                cats.push(attr);
+              }
+
+              var ordered = ['node', 'layout', 'text', 'view', 'border'];
+              for (var key in categories) {
+                if (ordered.indexOf(key) < 0) {
+                  ordered.splice(1, 0, key);
+                }
+              }
+
+              for (i=0;i < ordered.length;i++) {
+                var catname = ordered[i];
+                var catitems = categories[catname];
+                if (catitems) {
+                  var categoryName = catname.charAt(0).toUpperCase() + catname.slice(1);
+                  orderedcategories.push({
+                    name:categoryName,
+                    items:catitems.sort(function(a,b){
+                      var aweight = parseInt(a.weight || 0);
+                      var bweight = parseInt(b.weight || 0);
+                      if (aweight > bweight) {
+                        return 1;
+                      } else if (bweight > aweight) {
+                        return -1;
+                      } else if (b.name > a.name) {
+                        return -1;
+                      } else if (a.name > b.name) {
+                        return 1;
+                      }
+                      return 0;
+                    })
+                  })
+                }
               }
             }
-            this.stopActiveAnimators('height');
-            this.animate(animAttrs);
+            this.attributespanel.setAttribute('data', orderedcategories)
           </handler>
-          
-          <text with="button" name="header" width="60" textalign="right"
-            toppadding="4" bottompadding="4" fontsize="14" focusembellishment="false"
-            disabled="${!selectionmanager.selected || this.parent.height === 0}"
-          >
-            <method name="doActivated">
-              if (!this.disabled) this.parent.setActualAttribute('selected', !this.parent.selected);
-            </method>
-            <method name="drawDisabledState">
-              this.setActualAttribute('color', '#999999');
-            </method>
-            <method name="drawHoverState">
-              this.setActualAttribute('color', '#666666');
-            </method>
-            <method name="drawActiveState">
-              this.setActualAttribute('color', '#333333');
-            </method>
-            <method name="drawReadyState">
-              this.setActualAttribute('color', '#000000');
-            </method>
-          </text>
-          
-          <view name="content" width="100%" y="${this.parent.header.height}" maskfocus="${!this.parent.selected}">
-            <spacedlayout axis="y" spacing="5" inset="5">
-              <method name="update">
-                this.super();
-                if (this.canUpdate()) this.parent.parent.updateHeight();
-              </method>
-            </spacedlayout>
-            <replicator classname="attributeeditor">
-              <handler event="ondelayedselected" args="selected" reference="selectionmanager">
-                this.setAttribute('data', selected ? selected.getMoreAttrsListForDetails() : []);
-              </handler>
-            </replicator>
-          </view>
+
+
+          <replicator name="attributespanel">
+            <view leftpadding="10" toppadding="10" width="100%" height="auto">
+              <spacedlayout axis="y" updateparent="true" spacing="3"/>
+              <text text="$datapath{/name}"
+                fontsize="12"
+                toppadding="5"
+                leftpadding="3"
+                bottomborder="1"
+                bottompadding="3"
+                bordercolor="#eee"
+                color="#999"
+                layouthint='{"break":true}'></text>
+              <replicator classname="attributeeditor" data="$datapath{/items}"></replicator>
+            </view>
+
+          </replicator>
         </view>
       </view>
       

--- a/editor/editor_include.dre
+++ b/editor/editor_include.dre
@@ -892,7 +892,7 @@ either express or implied. See the License for the specific language governing p
         <spacedlayout axis="y" updateparent="true"/>
         
         <view width="100%" clip="true">
-          <spacedlayout axis="y" spacing="5" inset="5" outset="5" updateparent="true">
+          <spacedlayout axis="y" spacing="0" outset="5" updateparent="true">
             <method name="__positionView" args="view, attrName, value">
               // Only animate the parent updates so that the panel appears to
               // slide open/closed
@@ -953,9 +953,8 @@ either express or implied. See the License for the specific language governing p
             this.attributespanel.setAttribute('data', orderedcategories)
           </handler>
 
-
           <replicator name="attributespanel">
-            <view leftpadding="10" toppadding="10" width="100%" height="auto">
+            <view leftpadding="15" rightpadding="15" toppadding="5" width="100%">
               <spacedlayout axis="y" updateparent="true" spacing="3"/>
               <text text="$datapath{/name}"
                 fontsize="12"
@@ -965,10 +964,10 @@ either express or implied. See the License for the specific language governing p
                 bottompadding="3"
                 bordercolor="#eee"
                 color="#999"
-                layouthint='{"break":true}'></text>
-              <replicator classname="attributeeditor" data="$datapath{/items}"></replicator>
+                width="100%"
+              />
+              <replicator classname="attributeeditor" data="$datapath{/items}"/>
             </view>
-
           </replicator>
         </view>
       </view>

--- a/editor/subnodeeditor.dre
+++ b/editor/subnodeeditor.dre
@@ -6,7 +6,7 @@ either express or implied. See the License for the specific language governing p
 -->
 
 
-<class name="subnodeeditor" width="100%">
+<class name="subnodeeditor" width="100%" leftpadding="15" rightpadding="15">
   <method name="initNode" args="parent, attrs">
     this.super();
     this.label.setActualAttribute('text', this.data.klass.__displayName);
@@ -14,12 +14,12 @@ either express or implied. See the License for the specific language governing p
 
   <spacedlayout axis="y" spacing="5" outset="5" updateparent="true"/>
   
-  <text name="label" leftpadding="10" toppadding="6" bottompadding="6"
+  <text name="label" x="${-this.parent.leftpadding}" leftpadding="10" toppadding="6" bottompadding="6"
     topborder="1" bottomborder="1" bordercolor="${config.secondary_panel_color}"
-    bgcolor="#f8f8f8" color="${config.label_text_color}" fontsize="10" width="100%"
+    bgcolor="#f8f8f8" color="${config.label_text_color}" fontsize="10" width="${this.parent.width}"
   />
   
-  <smallbutton x="${this.parent.innerwidth - this.width - 2}" y="3" ignorelayout="true" text="delete">
+  <smallbutton x="right" y="3" ignorelayout="true" text="delete">
     <method name="doActivated">
       if (!this.disabled) {
         var target = this.classroot.data, E = dr.editor, undoClass;

--- a/editor/subnodeeditor.dre
+++ b/editor/subnodeeditor.dre
@@ -35,5 +35,5 @@ either express or implied. See the License for the specific language governing p
     </method>
   </smallbutton>
   
-  <replicator classname="attributeeditor" data="${this.parent.data.getAllAttrsListForDetails()}"/>
+  <replicator classname="attributeeditor" data="${this.parent.data.getAttrsListForDetails()}"/>
 </class>

--- a/lib/dr/Node.js
+++ b/lib/dr/Node.js
@@ -239,7 +239,7 @@ define(function(require, exports, module) {
               name: {
                 type: 'string',
                 value: '',
-                importance: -1,
+                category: 'node'
               }
             },
             

--- a/lib/dr/Node.js
+++ b/lib/dr/Node.js
@@ -239,6 +239,7 @@ define(function(require, exports, module) {
               name: {
                 type: 'string',
                 value: '',
+                weight:-1,
                 category: 'node'
               }
             },

--- a/lib/dr/animation/AnimBase.js
+++ b/lib/dr/animation/AnimBase.js
@@ -119,7 +119,6 @@ define(function(require, exports, module) {
               },
               repeat: {
                 type: 'number',
-                value: 1,
                 category:'animation'
               },
               
@@ -131,6 +130,7 @@ define(function(require, exports, module) {
               bounce: {
                 type: 'boolean',
                 value: false,
+                weight:1,
                 category:'animation'
               }/*,
               FIXME: need a mechanism to trigger play/stop and pause for animations

--- a/lib/dr/animation/AnimBase.js
+++ b/lib/dr/animation/AnimBase.js
@@ -110,39 +110,39 @@ define(function(require, exports, module) {
               delay: {
                 type: 'number',
                 value: 0,
-                importance: 10,
+                category:'animation'
               },
               duration: {
                 type: 'number',
                 value: 600, // Should be the same as dr.AnimBase.DEFAULT_DURATION
-                importance: 11,
+                category:'animation'
               },
               repeat: {
                 type: 'number',
                 value: 1,
-                importance: 12,
+                category:'animation'
               },
               
               reverse: {
                 type: 'boolean',
                 value: false,
-                importance: 13,
+                category:'animation'
               },
               bounce: {
                 type: 'boolean',
                 value: false,
-                importance: 14,
+                category:'animation'
               }/*,
               FIXME: need a mechanism to trigger play/stop and pause for animations
               running: {
                 type: 'boolean',
                 value: true,
-                importance: 0,
+                 category:'animation'
               },
               paused: {
                 type: 'boolean',
                 value: false,
-                importance: 0,
+                 category:'animation'
               }*/
             }
         },

--- a/lib/dr/animation/AnimGroup.js
+++ b/lib/dr/animation/AnimGroup.js
@@ -22,6 +22,7 @@ define(function(require, exports, module) {
               sequential: {
                 type: 'boolean',
                 value: false,
+                weight:1,
                 category:'animation'
               }
             },

--- a/lib/dr/animation/AnimGroup.js
+++ b/lib/dr/animation/AnimGroup.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
               sequential: {
                 type: 'boolean',
                 value: false,
-                importance: 15,
+                category:'animation'
               }
             },
             

--- a/lib/dr/animation/Animator.js
+++ b/lib/dr/animation/Animator.js
@@ -57,26 +57,31 @@ define(function(require, exports, module) {
               from: {
                 type: 'expression',
                 value: undefined,
+                weight:1,
                 category: 'animation'
               },
               to: {
                 type: 'expression',
                 value: undefined,
+                weight:2,
                 category: 'animation'
               },
               motion: {
                 type: 'motion',
                 value: 'inOutQuad',
+                weight:3,
                 category: 'animation'
               },
               attribute: {
                 type: 'string',
                 value: '',
+                weight:4,
                 category: 'animation'
               },
               relative: {
                 type: 'boolean',
                 value: false,
+                weight:4,
                 category: 'animation'
               }
             }

--- a/lib/dr/animation/Animator.js
+++ b/lib/dr/animation/Animator.js
@@ -57,27 +57,27 @@ define(function(require, exports, module) {
               from: {
                 type: 'expression',
                 value: undefined,
-                importance: 15,
+                category: 'animation'
               },
               to: {
                 type: 'expression',
                 value: undefined,
-                importance: 16,
+                category: 'animation'
               },
               motion: {
                 type: 'motion',
                 value: 'inOutQuad',
-                importance: 17,
+                category: 'animation'
               },
               attribute: {
                 type: 'string',
                 value: '',
-                importance: 18,
+                category: 'animation'
               },
               relative: {
                 type: 'boolean',
                 value: false,
-                importance: 19,
+                category: 'animation'
               }
             }
         },

--- a/lib/dr/view/View.js
+++ b/lib/dr/view/View.js
@@ -714,92 +714,111 @@ define(function(require, exports, module) {
               x: {
                 type: 'number',
                 value: 0,
-                importance: 10,
+                category:'layout',
+                weight:10
               },
               y: {
                 type: 'number',
                 value: 0,
-                importance: 11,
+                category:'layout',
+                weight:10
               },
               width: {
                 type: 'number',
                 value: 0,
-                importance: 12,
+                category:'layout',
+                weight:11
               },
               height: {
                 type: 'number',
                 value: 0,
-                importance: 13,
+                category:'layout',
+                weight:12
               },
               
               bgcolor: {
                 type: 'color',
                 value: 'transparent',
-                importance: 20,
+                category:'view',
+                editorname:'Background',
+                weight:1
               },
               
               border: {
                 type: 'number',
                 value: 0,
-                importance: 30,
+                editorname:'Width',
+                category:'border'
               },
               bordercolor: {
                 type: 'color',
                 value: 'transparent',
-                importance: 31,
+                editorname:'Color',
+                category:'border'
               },
               borderstyle: {
                 type: 'string',
                 value: 'solid',
-                importance: 32,
+                editorname:'Style',
+                category:'border'
               },
               
               opacity: {
                 type: 'number',
                 value: 1,
-                importance: 100,
+                category:'view',
+                weight:2
               },
               visible: {
                 type: 'boolean',
                 value: false,
-                importance: 101,
+                category:'view'
               },
               
               color: {
                 type: 'color',
                 value: 'inherit',
-                importance: 105,
+                category:'text',
+                weight:2
               },
               padding: {
                 type: 'number',
                 value: 0,
-                importance: 106,
+                category:'layout',
+                weight:20
               },
               cornerradius: {
                 type: 'number',
                 value: 0,
-                importance: 107,
+                editorname:'Corner Radius',
+                category:'border'
               },
               
               clip: {
                 type: 'boolean',
                 value: 'false',
-                importance: 110,
+                category:'view',
+                editorname:'Clip at Edge',
+                weight:11
               },
               scrollable: {
                 type: 'boolean',
                 value: 'false',
-                importance: 111,
+                category:'view',
+                weight:10
               },
               ignorelayout: {
                 type: 'boolean',
                 value: 'false',
-                importance: 120,
+                editorname:'Ignore Layout',
+                category:'layout'
               },
               layouthint: {
                 type: 'json',
                 value: '',
-                importance: 121,
+                category:'layout',
+                editorname:'Hint',
+                weight:30
               }
             }
         },


### PR DESCRIPTION
Attributes can now be given a `category`, a `weight` and an `editorname`.  Attributes will be grouped by category, then weighted by weight, with the larger weights sinking to the bottom of the list, and attributes with the same weights will be sorted alphabetically.    

Attributes' default category is the classname they are on, and defaults to 0 weight. 

The `editorname` is what text is actually displayed in the attributes panel, defaulting to the capitalized name of the attribute if none given.

Additionally, now any attributes automatically being set via constraints are now indicated with green text.
